### PR TITLE
Comment out Ubuntu support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,10 +26,22 @@ galaxy_info:
         # can't use Fedora 30.
         # - 30
         - 31
-    - name: Ubuntu
-      versions:
-        - bionic
-        - xenial
+    # For reasons I haven't been able to discern, the Ubuntu molecule
+    # tests work fine locally but fail in GitHub Actions due to being
+    # unable to perform some iptables operations.  I would think this
+    # was due to some kernel module not being loaded in the underlying
+    # host instance, except that the non-Ubuntu platforms pass just
+    # fine in GitHub Actions.
+    #
+    # I've already spent too much time on this, and we don't require
+    # the Ubuntu support right now, so I will make the executive
+    # decision to remove Ubuntu support for now.  I created this issue
+    # to document the error:
+    # https://github.com/cisagov/ansible-role-ufw/issues/3
+    # - name: Ubuntu
+    #   versions:
+    #     - bionic
+    #     - xenial
   galaxy_tags:
     - ufw
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -69,20 +69,32 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_bionic_systemd
-    image: geerlingguy/docker-ubuntu1604-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-  - name: ubuntu_xenial_systemd
-    image: geerlingguy/docker-ubuntu1804-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
+  # For reasons I haven't been able to discern, the Ubuntu molecule
+  # tests work fine locally but fail in GitHub Actions due to being
+  # unable to perform some iptables operations.  I would think this
+  # was due to some kernel module not being loaded in the underlying
+  # host instance, except that the non-Ubuntu platforms pass just fine
+  # in GitHub Actions.
+  #
+  # I've already spent too much time on this, and we don't require the
+  # Ubuntu support right now, so I will make the executive decision to
+  # remove Ubuntu support for now.  I created this issue to document
+  # the error:
+  # https://github.com/cisagov/ansible-role-ufw/issues/3
+  # - name: ubuntu_bionic_systemd
+  #   image: geerlingguy/docker-ubuntu1604-ansible:latest
+  #   privileged: yes
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   command: /lib/systemd/systemd
+  #   pre_build_image: yes
+  # - name: ubuntu_xenial_systemd
+  #   image: geerlingguy/docker-ubuntu1804-ansible:latest
+  #   privileged: yes
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   command: /lib/systemd/systemd
+  #   pre_build_image: yes
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
## 🗣 Description

This pull request comments out Ubuntu support for this Ansible role.

## 💭 Motivation and Context

For reasons I haven't been able to discern, the Ubuntu molecule tests work fine locally but fail in GitHub Actions due to being unable to perform some iptables operations.  I would think this was due to some kernel module not being loaded in the underlying host instance, except that the non-Ubuntu platforms pass just fine in GitHub Actions.

I've already spent too much time on this, and we don't require the Ubuntu support right now, so I will make the executive decision to remove Ubuntu support for now.  I created #3 to document the error.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
