### PR TITLE
Fix sporadic Fedora failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @jsf9k

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -16,16 +16,26 @@
       apt:
         update_cache: yes
 
-# The Fedora Docker images we are using
-# (geerlingguy/docker-fedora29-ansible:latest and
-# geerlingguy/docker-fedora31-ansible:latest) require the dnf cache to
-# be updated before they can successfully install anything.  At least,
-# they keep giving this error if I don't update the dnf cache:
+# When installing packages during later steps, the Fedora Docker
+# images we are using (geerlingguy/docker-fedora32-ansible:latest and
+# cisagov/docker-fedora33-ansible:latest) can throw sporadic errors
+# like: "No such file or directory:
+# '/var/cache/dnf/metadata_lock.pid'".
 #
-# No such file or directory: '/var/cache/dnf/metadata_lock.pid'
-- name: Update dnf cache (Fedora)
+# The fix is to ensure that systemd finishes initializing before
+# continuing on to the converge tasks.  For details see:
+# https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
+- name: Wait for systemd to complete initialization (Fedora)
   hosts: os_Fedora
   tasks:
-    - name: Update dnf cache
-      dnf:
-        update_cache: yes
+    - name: Wait for systemd to complete initialization # noqa 303
+      command: systemctl is-system-running
+      register: systemctl_status
+      until: "'running' in systemctl_status.stdout"
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+      # This task always runs, no matter what, so let's ignore this
+      # task when running the idempotence check.
+      tags:
+        - molecule-idempotence-notest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,11 @@
   package:
     name: "{{ ufw_package_names }}"
 
+- name: Configure UFW logging and state
+  ufw:
+    logging: "{{ logging }}"
+    state: "{{ state }}"
+
 # Unless you do this, systemd can sometimes get confused when you try
 # to enable a service you just installed
 - name: Systemd daemon-reload
@@ -30,8 +35,3 @@
   service:
     name: ufw
     enabled: yes
-
-- name: Configure the UFW service
-  ufw:
-    logging: "{{ logging }}"
-    state: "{{ state }}"


### PR DESCRIPTION
## 🗣 Description

This pull request fixes the sporadic Fedora failures when running `molecule test`.

## 💭 Motivation and Context

The dnf cache update I had put in before didn't always fix the problem, but @dav3r found this fix that actually works.  I cribbed this from what he did in [cisagov/ansible-role-pca-gophish-composition](https://github.com/cisagov/ansible-role-pca-gophish-composition).

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
