### PR TITLE
Modify /etc/ufw/sysctl.conf to improve security

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,29 @@
     logging: "{{ logging }}"
     state: "{{ state }}"
 
+# The following updates to /etc/ufw/sysctl.conf are done to harden
+# the operating system and are good general security practices.
+#
+# Note that /etc/ufw/sysctl.conf values overwrite those in /etc/sysctl.conf
+# which is why these changes are made here, rather than in
+# https://github.com/cisagov/ansible-role-hardening
+- name: Log martian (impossible address) packets
+  lineinfile:
+    path: /etc/ufw/sysctl.conf
+    regexp: "(?i)[^\\s #]*{{ item.name }}"
+    line: "{{ item.name }}={{ item.value }}"
+    state: present
+  loop:
+    - { name: "net/ipv4/conf/all/log_martians", value: "1"}
+    - { name: "net/ipv4/conf/default/log_martians", value: "1"}
+
+- name: Enable TCP SYN cookies
+  lineinfile:
+    path: /etc/ufw/sysctl.conf
+    regexp: "(?i)[^\\s #]*net/ipv4/tcp_syncookies"
+    line: "net/ipv4/tcp_syncookies=1"
+    state: present
+
 # Unless you do this, systemd can sometimes get confused when you try
 # to enable a service you just installed
 - name: Systemd daemon-reload


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR modifies several values in `/etc/ufw/sysctl.conf` so that they are more secure and will pass our security compliance audits.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Values in `/etc/ufw/sysctl.conf` take precedence over those in `/etc/sysctl.conf`, so these changes must be made here, rather than in [`ansible-role-hardening`](https://github.com/cisagov/ansible-role-hardening) to be effective.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass.  I also verified that `/etc/ufw/sysctl.conf` was modified as expected by running `molecule converge`, then logging in (`molecule login...`) to two host types that are of interest (Debian 10 and Fedora 32).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
