### PR TITLE
Add tasks to patch the UFW SystemD unit file for Kali Linux

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,3 +22,15 @@ def test_packages(host, pkg):
 def test_services(host, svc):
     """Test that the expected services are enabled."""
     assert host.service(svc).is_enabled
+
+
+def test_kali_ufw_unit_file(host):
+    """Test that the Kali ufw.service unit file was patched correctly."""
+    if host.system_info.distribution in [
+        "kali",
+    ]:
+        f = host.file("/usr/lib/systemd/system/ufw.service")
+        assert f.exists
+        assert f.is_file
+        assert not f.contains(r"^Wants=network-pre\.target$")
+        assert f.contains(r"^DefaultDependencies=no$")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,26 @@
     line: "net/ipv4/tcp_syncookies=1"
     state: present
 
+# The ufw systemd unit file in Kali Linux currently introduces a
+# dependency cycle that causes the cloud-init service not to run at
+# boot even if enabled.  (systemd refuses to run cloud-init.service in
+# order to break the cycle.)  Therefore we have to make a few fixes
+# here.
+- name: Fix buggy lines in Kali ufw.service unit file
+  block:
+    - name: Remove buggy Wants line in Kali ufw.service unit file
+      ansible.builtin.lineinfile:
+        line: Wants=network-pre.target
+        path: /usr/lib/systemd/system/ufw.service
+        state: absent
+    - name: Add DefaultDependencies line in Kali ufw.service unit file
+      ansible.builtin.lineinfile:
+        insertbefore: ^Before=network-pre\.target$
+        line: DefaultDependencies=no
+        path: /usr/lib/systemd/system/ufw.service
+  when: ansible_distribution == "Kali"
+
+
 # Unless you do this, systemd can sometimes get confused when you try
 # to enable a service you just installed
 - name: Systemd daemon-reload


### PR DESCRIPTION
## 🗣 Description ##

This pull request patches the SystemD unit file for UFW on Kali Linux to correct two bugs.

## 💭 Motivation and context ##

The UFW SystemD unit file for Kali linux contains a `Wants=network-pre.target` that is unnecessary.  It also lacks a `DefaultDependencies=no` line that _is_ necessary.  These errors cause a dependency cycle in SystemD, which SystemD breaks by refusing to start the [cloud-init]() service even if it is enabled.  This means that the instance userdata is not run, so this is a serious problem.

Resolves the Linux portion of cisagov/cool-system-internal#45.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also built a new Kali AMI using these changes and verified that it runs `cloud-init` as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
