### PR TITLE
Add GitHub Actions testing support for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,10 +214,7 @@ jobs:
       matrix:
         architecture:
           - amd64
-          # We cannot currently test _any_ ARM64 platforms under QEMU
-          # because QEMU cannot currently support iptables:
-          # https://github.com/multiarch/qemu-user-static/issues/191
-          # - arm64
+          - arm64
         platform:
           # Amazon Linux 2023 does not appear to offer ufw
           # - amazonlinux2023-systemd

--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ An Ansible role for installing [Uncomplicated
 Firewall](https://wiki.ubuntu.com/UncomplicatedFirewall?action=show&redirect=UbuntuFirewall)
 (UFW).
 
-> [!NOTE]
-> We cannot currently test *any* ARM64 platforms under QEMU because
-> [QEMU cannot currently support
-> `iptables`](https://github.com/multiarch/qemu-user-static/issues/191).
-
 ## Requirements ##
 
 None.


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds GitHub Actions testing support for ARM64.

Note that this pull request is built on top of #64 and will be merged after that one.

## 💭 Motivation and context ##

This platform was previously excluded from GitHub Actions testing because QEMU cannot support `iptables`, but now we test this platform in GitHub Actions using ARM runners so this exclusion is no longer necessary.

## 🧪 Testing ##

All automated tests (including on the ARM64 platform) pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.